### PR TITLE
poc for removing block params

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ in your Gemfile
 
 ```ruby
 # Basic query
-query = Graphlyte.query do |q|
-  q.all_todos do |q|
+query = Graphlyte.query do
+  q.all_todos do
     # specify fields for your query
     q.id
     q.status
@@ -48,18 +48,19 @@ RestClient.post("http://localhost", query.to_json, { "Content-Type" => "applicat
 ### Fragments / Nested Fragments
 
 ```ruby
-extra_fields = Graphlyte.fragment('extraFields', "Todo") do |f|
+extra_fields = Graphlyte.fragment('extraFields', "Todo") do
   f.id
   f.status
 end
 
+# pass a block parameter if you want to merge/spread fieldsets or fragments
 todo = Graphlyte.fragment('todoFields', "Todo") do |f|
   f.title
   f << extra_fields
 end
 
-query = Graphlyte.query do |q|
-  q.all_todos todo
+query = Graphlyte.query do
+  all_todos todo
 end
 
 puts query.to_s
@@ -85,12 +86,12 @@ fragment extraFields on Todo {
 ### input and aliases
 
 ```ruby
-query = Graphlyte.query do |q|
-  q.User(id: 123).alias("sean") do |u|
-    u.id
+query = Graphlyte.query do
+  User(id: 123).alias("sean") do
+    id
   end
-  q.User(id: 456).alias("bob") do |u|
-    u.id
+  User(id: 456).alias("bob") do
+    id
   end
 end
 

--- a/graphlyte.gemspec
+++ b/graphlyte.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'graphlyte'
-  s.version     = '0.1.3'
+  s.version     = '0.1.4'
   s.licenses    = ['MIT']
   s.summary     = "craft graphql queries with ruby"
   s.description = "craft graphql queries with ruby"

--- a/lib/graphlyte.rb
+++ b/lib/graphlyte.rb
@@ -20,7 +20,7 @@ module Graphlyte
 
   def self.build(&block)
     builder = Builder.new
-    block.call(builder) if block
+    builder.>.instance_eval(&block)
     builder
   end
 end

--- a/lib/graphlyte/builder.rb
+++ b/lib/graphlyte/builder.rb
@@ -26,7 +26,7 @@ module Graphlyte
         field = Field.new(method, Fieldset.empty, fieldset_or_hargs)
       end
 
-      block.call(field.fieldset.builder) if block
+      field.fieldset.builder.>.instance_eval(&block) if block
       @fields << field
       field
     end
@@ -34,6 +34,10 @@ module Graphlyte
     # for internal use only
     def >>
       @fields
+    end
+
+    def >
+      self
     end
   end
 end

--- a/lib/graphlyte/field.rb
+++ b/lib/graphlyte/field.rb
@@ -17,7 +17,7 @@ module Graphlyte
 
     def alias(name, &block)
       @alias = name
-      block.call(fieldset.builder) if block
+      fieldset.builder.>.instance_eval(&block) if block
     end
 
     def to_s(indent=0)

--- a/spec/argument_values_spec.rb
+++ b/spec/argument_values_spec.rb
@@ -1,8 +1,8 @@
 describe Graphlyte do 
   it "should support integers" do 
-    query = Graphlyte.query do |q|
-      q.arguments(int: 1) do |i|
-        i.id
+    query = Graphlyte.query do
+      arguments(int: 1) do
+        id
       end 
     end
     expect(query.to_s).to eql(<<~STRING)

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -53,12 +53,12 @@ describe Graphlyte do
   end
 
   it "should support aliases and input" do 
-    query = Graphlyte.query do |q|
-      q.User(id: 123).alias("sean") do |u|
-        u.id
+    query = Graphlyte.query do
+      User(id: 123).alias("sean") do
+        id
       end
-      q.User(id: 456).alias("bob") do |u|
-        u.id
+      User(id: 456).alias("bob") do
+        id
       end
     end
 


### PR DESCRIPTION
this PR allows one to do 
```ruby

fieldset = Graphlyte.fieldset do 
  id 
  hello
  two do 
    three(one: 1, four: "asdfsaf")
  end
end
```
however, in order to use the spread operator, you still must pass a block parameter.
```ruby
query = Graphlyte.query do |f|
  f << fieldset
end
```